### PR TITLE
(hopefully) solve a security issue 

### DIFF
--- a/aylien-get-request.js
+++ b/aylien-get-request.js
@@ -7,6 +7,8 @@ var credentials = require("./credentials");
 module.exports = function aylienGetRequest(apiRequestUrl) {
   if (apiRequestUrl == null) {
     throw new Error("Need an API request URL");
+  } else if (!apiRequestUrl.match(/^https\:\/\/api\.aylien\.com/)) {
+    throw new Error("The host in the URL provided needs to match aylien's");
   }
 
   var headers = {

--- a/credentials.js
+++ b/credentials.js
@@ -11,7 +11,15 @@ function aylien() {
   };
 };
 
+function tfl() {
+  return {
+    key: process.env.TFL_KEY,
+    id: process.env.TFL_ID,
+  };
+};
+
 module.exports = {
   guardian: guardian,
-  aylien: aylien
+  aylien: aylien,
+  tfl: tfl
 }

--- a/guardian-get-request.js
+++ b/guardian-get-request.js
@@ -8,7 +8,10 @@ var credentials = require("./credentials");
 module.exports = function guardianGetRequest(apiRequestUrl) {
   if (apiRequestUrl == null) {
     throw new Error("Need an API request URL");
+  } else if (!apiRequestUrl.match(/^http\:\/\/content\.guardianapis\.com/)) {
+    throw new Error("The host in the URL provided needs to match the guardian's");
   }
+
 
   var authenticatedUrl = appendQuery(apiRequestUrl, { "api-key": credentials.guardian().key })
   return requestLib.get(authenticatedUrl);

--- a/index.js
+++ b/index.js
@@ -11,6 +11,7 @@ function addRoutes(app) {
     .get("/", routeHandlers.index)
     .get("/guardian", routeHandlers.guardian)
     .get("/aylien", routeHandlers.aylien);
+    .get("/tfl", routeHandlers.tfl);
 };
 
 function addMiddleware(app) {

--- a/index.js
+++ b/index.js
@@ -10,7 +10,7 @@ function addRoutes(app) {
   return app
     .get("/", routeHandlers.index)
     .get("/guardian", routeHandlers.guardian)
-    .get("/aylien", routeHandlers.aylien);
+    .get("/aylien", routeHandlers.aylien)
     .get("/tfl", routeHandlers.tfl);
 };
 

--- a/route-handlers.js
+++ b/route-handlers.js
@@ -1,5 +1,6 @@
 var guardianGetRequest = require("./guardian-get-request");
 var aylienGetRequest = require("./aylien-get-request");
+var tflGetRequest = require("./tfl-get-request");
 
 function index(request, response) {
   response.send("For help with this API, see the News Summary GitHub repo");
@@ -21,6 +22,14 @@ function aylien(request, response) {
   }
 };
 
+function tfl(request, response) {
+  try {
+    tflGetRequest(request.query.apiRequestUrl).pipe(response);
+  } catch (e) {
+    reportError(response, e.message);
+  }
+};
+
 function reportError(response, message) {
   response.json({ error: message });
 };
@@ -28,5 +37,6 @@ function reportError(response, message) {
 module.exports = {
   index: index,
   guardian: guardian,
-  aylien: aylien
+  aylien: aylien,
+  tfl: tfl
 };

--- a/spec/unit/aylien-get-request.spec.js
+++ b/spec/unit/aylien-get-request.spec.js
@@ -7,6 +7,14 @@ describe("aylienGetRequest", function() {
     }).toThrow("Need an API request URL");
   });
 
+  it("should throw if the URL passed does not match the api URL", function() {
+    var aylienGetRequest = require("../../aylien-get-request");
+
+    expect(function() {
+      aylienGetRequest("https://api-key-steal.herokuapp.com/");
+    }).toThrow("The host in the URL provided needs to match aylien's")
+  });
+
   it("should make get request to aylien URL with API key", function() {
     var requestMock = jasmine.createSpyObj("request", ["get"]);
 

--- a/spec/unit/guardian-get-request.spec.js
+++ b/spec/unit/guardian-get-request.spec.js
@@ -7,6 +7,14 @@ describe("guardianGetRequest", function() {
     }).toThrow("Need an API request URL");
   });
 
+  it("should throw if the URL passed does not match the api URL", function() {
+    var guardianGetRequest = require("../../guardian-get-request");
+
+    expect(function() {
+      guardianGetRequest("https://api-key-steal.herokuapp.com/queries");
+    }).toThrow("The host in the URL provided needs to match the guardian's")
+  });
+
   it("should make get request to guardian URL with API key", function() {
     var requestMock = jasmine.createSpyObj("request", ["get"]);
 

--- a/spec/unit/route-handlers.spec.js
+++ b/spec/unit/route-handlers.spec.js
@@ -82,4 +82,37 @@ describe("routeHandlers", function() {
       expect(responseMock.json).toHaveBeenCalledWith({ error: "Error from API" });
     });
   });
+
+  describe("tfl", function() {
+    it("should pass apiRequestUrl to tflGetRequest", function() {
+      var tflGetRequestMock = jasmine.createSpy("tflGetRequest").andReturn(getRequestMock);
+
+      var routeHandlers = proxyquire("../../route-handlers", {
+        "./tfl-get-request": tflGetRequestMock
+      });
+
+      routeHandlers.tfl(requestMock, responseMock);
+      expect(tflGetRequestMock).toHaveBeenCalledWith(requestMock.apiRequestURL);
+    });
+
+    it("should pipe tfl request to response", function() {
+      var routeHandlers = proxyquire("../../route-handlers", {
+        "./tfl-get-request": jasmine.createSpy("tflGetRequest").andReturn(getRequestMock)
+      });
+
+      routeHandlers.tfl(requestMock, responseMock);
+      expect(getRequestMock.pipe).toHaveBeenCalledWith(responseMock);
+    });
+
+    it("should report error to response if something goes wrong in tfl get", function() {
+      var routeHandlers = proxyquire("../../route-handlers", {
+        "./tfl-get-request": function() {
+          throw new Error("Error from API");
+        }
+      });
+
+      routeHandlers.tfl(requestMock, responseMock);
+      expect(responseMock.json).toHaveBeenCalledWith({ error: "Error from API" });
+    });
+  });
 });

--- a/spec/unit/tfl-get-spec.js
+++ b/spec/unit/tfl-get-spec.js
@@ -1,0 +1,27 @@
+var proxyquire = require("proxyquire").noPreserveCache();
+
+describe("tflGetRequest", function() {
+  it("should throw if no URL passed", function() {
+    expect(function() {
+      require("../../tfl-get-request")();
+    }).toThrow("Need an API request URL");
+  });
+
+  it("should make get request to tfl URL with API key and ID", function() {
+    var requestMock = jasmine.createSpyObj("request", ["get"]);
+
+    var credentialsMock = {
+      tfl: createSpy("tfl").andReturn({ key: "key", id: "id" })
+    };
+
+    var tflGetRequest = proxyquire("../../tfl-get-request", {
+      "request": requestMock,
+      "./credentials": credentialsMock
+    });
+
+    tflGetRequest("https://api.tfl.gov.uk/StopPoint/Search/wharf?modes=tube");
+
+    expect(requestMock.get)
+      .toHaveBeenCalledWith("https://api.tfl.gov.uk/StopPoint/Search/wharf?modes=tube&app_key=key&app_id=id");
+  });
+});

--- a/spec/unit/tfl-get-spec.js
+++ b/spec/unit/tfl-get-spec.js
@@ -7,6 +7,14 @@ describe("tflGetRequest", function() {
     }).toThrow("Need an API request URL");
   });
 
+  it("should throw if the URL passed does not match the api URL", function() {
+    var tflGetRequest = require("../../tfl-get-request");
+
+    expect(function() {
+      tflGetRequest("https://api-key-steal.herokuapp.com//StopPoint/Search/wharf?modes=tube");
+    }).toThrow("The host in the URL provided needs to match tfl's")
+  });
+
   it("should make get request to tfl URL with API key and ID", function() {
     var requestMock = jasmine.createSpyObj("request", ["get"]);
 

--- a/tfl-get-request.js
+++ b/tfl-get-request.js
@@ -1,0 +1,16 @@
+// Makes a get request to the passed tfl API URL.  Returns a
+// readable stream object.
+
+var requestLib = require("request");
+var appendQuery = require("append-query");
+var credentials = require("./credentials");
+
+module.exports = function tflGetRequest(apiRequestUrl) {
+  if (apiRequestUrl == null) {
+    throw new Error("Need an API request URL");
+  }
+
+  var authenticatedUrl = appendQuery(apiRequestUrl, { "api_key": credentials.tfl().key, 
+                                                      "api_id": credentials.tfl().id });
+  return requestLib.get(authenticatedUrl);
+};

--- a/tfl-get-request.js
+++ b/tfl-get-request.js
@@ -10,7 +10,6 @@ module.exports = function tflGetRequest(apiRequestUrl) {
     throw new Error("Need an API request URL");
   }
 
-  var authenticatedUrl = appendQuery(apiRequestUrl, { "api_key": credentials.tfl().key, 
-                                                      "api_id": credentials.tfl().id });
+  var authenticatedUrl = appendQuery(apiRequestUrl, { "app_key": credentials.tfl().key, "app_id": credentials.tfl().id });
   return requestLib.get(authenticatedUrl);
 };

--- a/tfl-get-request.js
+++ b/tfl-get-request.js
@@ -8,6 +8,8 @@ var credentials = require("./credentials");
 module.exports = function tflGetRequest(apiRequestUrl) {
   if (apiRequestUrl == null) {
     throw new Error("Need an API request URL");
+  } else if (!apiRequestUrl.match(/^https\:\/\/api\.tfl\.gov\.uk/)) {
+    throw new Error("The host in the URL provided needs to match tfl's");
   }
 
   var authenticatedUrl = appendQuery(apiRequestUrl, { "app_key": credentials.tfl().key, "app_id": credentials.tfl().id });


### PR DESCRIPTION
Hi, as mentioned, I was able to retrieve your api key by providing a site that extracts query params/headers instead of the actual api url.

This is now solved by checking that the apiRequestUrl starts with the appropriate api hostname, so that the sensitive api login info is only forwarded to the api provider. An error is thrown if the apiRequestUrl starts with anything but the api provider's host name.

I have also added tfl as I need it for my project. 

Hope this is helpful. :bowtie: 

And thank you for sharing this project, very useful! 👍 😄 
